### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Requirements:
   * docker
 
 #### Step 1
-Install docker. You can find docker and a installation guide [on the Docker homepage.](https://www.docker.com/products/docker)
+Install docker and docker-compose. You can find docker, docker-compose, and a installation guide [on the Docker homepage.](https://docs.docker.com/compose/install/)
 
 #### Step 2
 Download the newest version of pogo-cruncher.


### PR DESCRIPTION
Using Ubuntu 16.04, docker-compose is not part of the docker.io installation using the package manager.
Add docker-compose to the list of requirements and how to install it.