### PR TITLE
Swap docker images to use alpine bases, decrease image size and build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,19 @@
-FROM python:3.5
+FROM python:3.5-alpine
 MAINTAINER Christian Meter <cmeter@googlemail.com>
 
-RUN mkdir /code
+RUN apk add --no-cache git gcc musl-dev && \
+    mkdir /code
+
 WORKDIR /code
 
-ADD requirements.txt /code
-RUN pip install -U pip
+COPY requirements.txt /code
+
 RUN pip install -r requirements.txt
 
-ADD app.py /code
-ADD backend /code/backend
+COPY app.py /code
+COPY backend /code/backend
 
 EXPOSE 5000
-CMD export FLASK_APP=/code/app.py
+ENV FLASK_APP /code/app.py
+
 CMD flask run --host=0.0.0.0

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,32 +1,24 @@
-FROM clojure
+FROM clojure:alpine
 MAINTAINER Christian Meter <cmeter@googlemail.com>
 
-# Add sources for nodejs
-RUN curl -sL https://deb.nodesource.com/setup_6.x | bash -
-
-RUN apt-get update -qq
-RUN apt-get install -yqq rubygems nodejs
-RUN yes | gem install sass
-RUN npm install bower -g
-
-RUN mkdir ./frontend
-WORKDIR /frontend
+RUN apk add --no-cache nodejs ruby git python && \
+    (gem install sass; exit 0) && \
+    npm install bower -g && \
+    mkdir /frontend
 
 ADD . /frontend
 
 # Load bower dependencies
-RUN GIT_DIR=/tmp bower install --allow-root
+RUN cd /frontend && \
+    GIT_DIR=/tmp bower install --allow-root && \
+    lein deps && \
+    lein cljsbuild once min && \
+    cd /frontend/resources/public && \
+    sass css/style.sass css/style.css --style compressed && \
+    rm -rf .sass-cache
 
-# Install clojurescript dependencies and build minified js file
-RUN lein deps
-RUN lein cljsbuild once min
-
-# Now let's create the remaining web components
 WORKDIR /frontend/resources/public
-
-RUN sass css/style.sass css/style.css --style compressed
-RUN rm -rf .sass-cache
 
 # Start SimpleHTTPServer to serve application
 EXPOSE 8888
-CMD python2 -m SimpleHTTPServer 8888
+CMD python -m SimpleHTTPServer 8888


### PR DESCRIPTION
I prefetched all the base images, so the build times are purely build times of these Dockerfiles

**Frontend**
Current docker images:
```
Build time:
real	4m5.485s
user	0m0.262s
sys	0m0.065s

REPOSITORY                     TAG                 IMAGE ID            CREATED             SIZE
pogocruncher_frontend          latest              6310ea4af1fb        6 seconds ago       846.3 MB
```

New alpine based docker image:
```
Build time:
real	1m18.843s
user	0m0.246s
sys	0m0.057s

REPOSITORY                     TAG                 IMAGE ID            CREATED              SIZE
pogocruncher_frontend          latest              f9ae5171353a        19 seconds ago      337.1 MB
```

**Backend**
Current docker images:
```
Build time:
real	0m31.125s
user	0m0.200s
sys	0m0.059s

REPOSITORY                     TAG                 IMAGE ID            CREATED             SIZE
pogocruncher_backend           latest              3e2f1c729a98        About a minute ago   741.2 MB
```

New alpine based docker image:
```
Build time:
real	0m36.674s
user	0m0.202s
sys	0m0.062s

REPOSITORY                     TAG                 IMAGE ID            CREATED              SIZE
pogocruncher_backend           latest              4cec61c8758f        14 seconds ago       226.9 MB
```
